### PR TITLE
extract `git_client` and `runners` modules

### DIFF
--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -1,0 +1,181 @@
+use colored::Colorize;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+const WORKTREE_DIR: &str = "gitavs-worktree";
+
+use crate::runners::tests;
+
+#[derive(Default)]
+struct Commit {
+    pub sha: String,
+    pub message: String,
+}
+
+enum Subcommand {
+    Diff,
+    Log,
+    Switch,
+    Worktree
+}
+
+impl Subcommand {
+    fn build(&self) -> &str {
+        match self {
+            Subcommand::Log => "log",
+            Subcommand::Diff => "diff",
+            Subcommand::Switch => "switch",
+            Subcommand::Worktree => "worktree"
+        }
+    }
+}
+
+pub fn do_work(from_sha: String, mut cached_files: Vec<String>) {
+    create_worktree();
+
+    match Command::new("cd")
+        .arg(WORKTREE_DIR)
+        .output() {
+            Ok(_) => (),
+            Err(err) => {
+                eprintln!("Could not cd: {}", err);
+                std::process::exit(-1);
+            }
+        }
+
+    let commits: Vec<Commit> = get_commits(from_sha);
+
+    for commit_pair in commits.windows(2) {
+        print!(
+            "{} {} ",
+            &commit_pair[1].sha.yellow(),
+            &commit_pair[1].message
+        );
+
+        io::stdout().flush().expect("Failed to flush stdout");
+
+        let changed_files = get_changed_files(&commit_pair[0].sha, &commit_pair[1].sha);
+
+        if changed_files.is_empty() {
+            print!("{}\n", "No test files".bright_blue().bold());
+            continue;
+        }
+
+        for file in &changed_files {
+            if !cached_files.contains(&file) {
+                cached_files.push(file.to_string());
+            }
+        }
+
+        switch(&commit_pair[1].sha);
+
+        tests::rspec::run(&cached_files);
+
+        switch(&"-".to_string());
+
+        print!("\n");
+    }
+
+    delete_worktree();
+}
+
+fn get_commits(from_sha: String) -> Vec<Commit> {
+    let child = match Command::new("git")
+        .args([Subcommand::Log.build(), &format!("{from_sha}^.."), "--reverse", "--format=%h %s"])
+        .stdout(Stdio::piped())
+        .spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                eprintln!("Error spawning process: {}", err);
+                std::process::exit(1);
+            }
+        };
+
+    match child
+        .stdout
+        .map(|stdout| {
+            BufReader::new(stdout)
+                .lines()
+                .map(|line| build_commit(line))
+                .collect::<Vec<Commit>>()
+        }) {
+            Some(val) => val,
+            None => {
+                eprintln!("No commit returned?");
+                Vec::new()
+            }
+        }
+}
+
+fn get_changed_files(sha_1: &String, sha_2: &String) -> Vec<String> {
+    let child = match Command::new("git")
+        .args([Subcommand::Diff.build(), "--name-only", &sha_1, &sha_2])
+        .stdout(Stdio::piped())
+        .spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                eprintln!("Error spawning process: {}", err);
+                std::process::exit(1);
+            }
+        };
+
+    child
+        .stdout
+        .map(|stdout| {
+            BufReader::new(stdout)
+                .lines()
+                .map(|line| line.expect("error"))
+                .filter(|line| { 
+                    line.ends_with("_spec.rb") ||
+                    line.ends_with("_test.rb")
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn switch(value: &String) {
+    match Command::new("git")
+        .args([Subcommand::Switch.build(), &format!("{}", value)])
+        .output() {
+            Ok(_) => (),
+            Err(err) => {
+                eprintln!("Failed to switch: {}", err);
+                std::process::exit(-1);
+            }
+        }
+}
+
+fn create_worktree() {
+    match Command::new("git")
+        .args([Subcommand::Worktree.build(), "add", "-d",  WORKTREE_DIR])
+        .output() {
+            Ok(_) => (),
+            Err(err) => {
+                eprintln!("Failed to add worktree: {}", err);
+                std::process::exit(-1);
+            }
+        }
+}
+
+fn delete_worktree() {
+    match Command::new("git")
+        .args([Subcommand::Worktree.build(), "remove", WORKTREE_DIR])
+        .output() {
+            Ok(_) => (),
+            Err(err) => {
+                eprintln!("Failed to remove worktree: {}", err);
+                std::process::exit(-1);
+            }
+        }
+}
+
+fn build_commit<E>(line: Result<String, E>) -> Commit {
+    match line.unwrap_or_default().split_once(" ") {
+        Some((sha, message)) => Commit {
+            sha: sha.to_string(),
+            message: message.to_string(),
+        },
+        None => Commit::default(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
-use colored::Colorize;
 use std::env::args;
-use std::io::{self, BufRead, BufReader, Write};
-use std::process::{Command, Stdio};
 
-#[derive(Default)]
-struct Commit {
-    sha: String,
-    message: String,
-}
+mod git_client;
+mod runners;
 
 fn main() {
-    let mut cached_files: Vec<String> = vec![];
+    let cached_files: Vec<String> = vec![];
     let args: Vec<String> = args().collect();
     let mut from_sha = "main";
 
@@ -18,135 +12,5 @@ fn main() {
         from_sha = &args[1];
     }
 
-    create_worktree();
-
-    Command::new("cd")
-        .arg("gitavs-workree")
-        .output()
-        .expect("error");
-
-    let commits: Vec<Commit> = get_commits(from_sha.to_string());
-
-    for commit_pair in commits.windows(2) {
-        print!(
-            "{} {} ",
-            &commit_pair[1].sha.yellow(),
-            &commit_pair[1].message
-        );
-
-        io::stdout().flush().expect("Failed to flush stdout");
-
-        let changed_files = get_changed_files(&commit_pair[0].sha, &commit_pair[1].sha);
-
-        if changed_files.is_empty() {
-            print!("{}\n", "No test files".bright_blue().bold());
-            continue;
-        }
-
-        for file in &changed_files {
-            if !cached_files.contains(&file) {
-                cached_files.push(file.to_string());
-            }
-        }
-
-        switch(&commit_pair[1].sha);
-
-        for file in &changed_files {
-            if !cached_files.contains(&file) {
-                cached_files.push(file.to_string());
-            }
-        }
-
-        run_tests(&cached_files);
-
-        switch(&"-".to_string());
-
-        print!("\n");
-    }
-
-    delete_worktree();
-}
-
-fn get_commits(from_sha: String) -> Vec<Commit> {
-    let child = Command::new("git")
-        .args(["log", &format!("{from_sha}^.."), "--reverse", "--format=%h %s"])
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("error");
-
-    child
-        .stdout
-        .map(|stdout| {
-            BufReader::new(stdout)
-                .lines()
-                .map(|line| build_commit(line))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn build_commit<E>(line: Result<String, E>) -> Commit {
-    match line.unwrap_or_default().split_once(" ") {
-        Some((sha, message)) => Commit {
-            sha: sha.to_string(),
-            message: message.to_string(),
-        },
-        None => Commit::default(),
-    }
-}
-
-fn get_changed_files(sha_1: &String, sha_2: &String) -> Vec<String> {
-    let child = Command::new("git")
-        .args(["diff", "--name-only", &sha_1, &sha_2])
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("error");
-
-    child
-        .stdout
-        .map(|stdout| {
-            BufReader::new(stdout)
-                .lines()
-                .map(|line| line.expect("error"))
-                .filter(|line| line.ends_with("_spec.rb"))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn switch(value: &String) {
-    Command::new("git")
-        .args(["switch", &format!("{}", value)])
-        .output()
-        .expect("error");
-}
-
-fn create_worktree() {
-    Command::new("git")
-        .args(["worktree", "add", "-d",  "gitavs-worktree"])
-        .output()
-        .expect("error");
-}
-
-fn delete_worktree() {
-    Command::new("git")
-        .args(["worktree", "remove", "gitavs-worktree"])
-        .output()
-        .expect("error");
-}
-
-fn run_tests(cached_files: &Vec<String>) {
-    let test_runner_command = Command::new("bundle")
-        .args(["exec", "rspec"])
-        .args(cached_files)
-        .output()
-        .expect("error");
-
-    if test_runner_command.status.code() == Some(1) {
-        println!("{} ❌\n", "Failed!".bright_red().bold());
-        println!("{}\n", "RSpec output:".bright_blue().bold());
-        io::stdout().write_all(&test_runner_command.stdout).unwrap();
-    } else {
-        print!("{} ✅", "Success!".bright_green().bold());
-    }
+    git_client::do_work(from_sha.to_string(), cached_files)
 }

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -1,0 +1,23 @@
+pub mod tests {
+    pub mod rspec {
+        use colored::Colorize;
+        use std::process::Command;
+        use std::io::{self, Write};
+
+        pub fn run(cached_files: &Vec<String>) {
+            let test_runner_command = Command::new("bundle")
+                .args(["exec", "rspec"])
+                .args(cached_files)
+                .output()
+                .expect("error");
+
+            if test_runner_command.status.code() == Some(1) {
+                println!("{} ❌\n", "Failed!".bright_red().bold());
+                println!("{}\n", "RSpec output:".bright_blue().bold());
+                io::stdout().write_all(&test_runner_command.stdout).unwrap();
+            } else {
+                print!("{} ✅", "Success!".bright_green().bold());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a larger refactor to start separating concerns by extracting modules out of `main.rs` to handle specific pieces of functionality.

This adds the `git_client` and `runners` modules which will be used to interact with `git`, and add new runners to perform things like linting, syntax checking, in addition to running tests.