### PR TITLE
:wrench: Optionally symlink `node_modules` for `rspec` runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -98,21 +98,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
-name = "colored"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
-dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "gitavs"
 version = "0.1.0"
 dependencies = [
  "clap",
- "colored",
 ]
 
 [[package]]
@@ -126,12 +115,6 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "proc-macro2"
@@ -182,35 +165,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -219,21 +178,15 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -243,21 +196,9 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -273,21 +214,9 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -297,21 +226,9 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-colored = "2"

--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -2,10 +2,10 @@ use std::env::set_current_dir;
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{self, Command, Stdio};
 
+use crate::runners;
+
 const GIT: &str = "git";
 const WORKTREE_DIR: &str = "gitavs-worktree";
-
-use crate::runners::tests;
 
 #[derive(Default)]
 struct Commit {
@@ -68,7 +68,7 @@ pub fn do_work(from_sha: String) {
 
         checkout(&commit_pair[1].sha);
 
-        tests::rspec::run(&cached_files);
+        runners::ruby::tests::rspec::run(&cached_files);
 
         checkout(&"-".to_string());
 

--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -1,4 +1,3 @@
-use colored::Colorize;
 use std::env::set_current_dir;
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{self, Command, Stdio};
@@ -48,7 +47,7 @@ pub fn do_work(from_sha: String) {
     for commit_pair in commits.windows(2) {
         print!(
             "{} {} ",
-            &commit_pair[1].sha.yellow(),
+            &commit_pair[1].sha,
             &commit_pair[1].message
         );
 
@@ -57,7 +56,7 @@ pub fn do_work(from_sha: String) {
         let changed_files = get_changed_files(&commit_pair[0].sha, &commit_pair[1].sha);
 
         if changed_files.is_empty() {
-            print!("{}\n", "No test files".bright_blue().bold());
+            print!("{}\n", "No test files");
             continue;
         }
 

--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -40,7 +40,7 @@ pub fn do_work(from_sha: String) {
     if set_current_dir(&format!("../{WORKTREE_DIR}").to_string()).is_err() {
         eprintln!("Error, couldn't change to worktree directory");
         delete_worktree();
-        process::exit(-1);
+        process::exit(1);
     }
 
     let commits: Vec<Commit> = get_commits(from_sha);

--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -1,4 +1,4 @@
-use std::env::set_current_dir;
+use std::env::{current_dir, set_current_dir};
 use std::io::{self, BufRead, BufReader, Write};
 use std::process::{self, Command, Stdio};
 
@@ -33,6 +33,7 @@ impl Subcommand {
 
 pub fn do_work(from_sha: String) {
     let mut cached_files: Vec<String> = vec![];
+    let repo_dir = current_dir().unwrap();
 
     create_worktree();
 
@@ -41,6 +42,8 @@ pub fn do_work(from_sha: String) {
         delete_worktree();
         process::exit(1);
     }
+
+    runners::ruby::tests::rspec::setup_environment(repo_dir);
 
     let commits: Vec<Commit> = get_commits(from_sha);
 

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -1,6 +1,5 @@
 pub mod tests {
     pub mod rspec {
-        use colored::Colorize;
         use std::process::Command;
         use std::io::{self, Write};
 
@@ -12,11 +11,11 @@ pub mod tests {
                 .expect("error");
 
             if test_runner_command.status.code() == Some(1) {
-                println!("{} ❌\n", "Failed!".bright_red().bold());
-                println!("{}\n", "RSpec output:".bright_blue().bold());
+                println!("{} ❌\n", "Failed!");
+                println!("{}\n", "RSpec output:");
                 io::stdout().write_all(&test_runner_command.stdout).unwrap();
             } else {
-                print!("{} ✅", "Success!".bright_green().bold());
+                print!("{} ✅", "Success!");
             }
         }
     }

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -1,21 +1,34 @@
-pub mod tests {
-    pub mod rspec {
-        use std::process::Command;
-        use std::io::{self, Write};
+pub mod ruby {
+    const BUNDLE: &str = "bundle";
 
-        pub fn run(cached_files: &Vec<String>) {
-            let test_runner_command = Command::new("bundle")
-                .args(["exec", "rspec"])
-                .args(cached_files)
-                .output()
-                .expect("error");
+    pub mod tests {
+        pub mod rspec {
+            use std::io::{self, Write};
+            use std::process;
+            use std::process::Command;
 
-            if test_runner_command.status.code() == Some(1) {
-                println!("{} ❌\n", "Failed!");
-                println!("{}\n", "RSpec output:");
-                io::stdout().write_all(&test_runner_command.stdout).unwrap();
-            } else {
-                print!("{} ✅", "Success!");
+            use crate::runners::ruby::BUNDLE;
+
+            pub fn run(cached_files: &Vec<String>) {
+                let child = match Command::new(BUNDLE)
+                    .args(["exec", "rspec"])
+                    .args(cached_files)
+                    .output()
+                {
+                    Ok(output) => output,
+                    Err(err) => {
+                        eprintln!("Error running bundle exec rspec: {}", err);
+                        process::exit(1)
+                    }
+                };
+
+                if child.status.code() == Some(1) {
+                    println!("{} ❌\n", "Failed!");
+                    println!("{}\n", "RSpec output:");
+                    io::stdout().write_all(&child.stdout).unwrap();
+                } else {
+                    print!("{} ✅", "Success!");
+                }
             }
         }
     }

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -33,3 +33,43 @@ pub mod ruby {
         }
     }
 }
+
+pub mod node {
+    use std::{
+        env::current_dir,
+        os::unix::fs::symlink,
+        path::PathBuf,
+        process::{self, Command},
+    };
+
+    const NODE_MODULES: &str = "node_modules";
+    const YARN: &str = "yarn";
+    pub const PACKAGE_JSON: &str = "package.json";
+
+    pub fn setup_environment(repo_dir: PathBuf) {
+        symlink_node_modules(repo_dir);
+
+        _ = match Command::new(YARN).output() {
+            Ok(_) => (),
+            Err(err) => {
+                eprintln!("Failed to run npm: {}", err);
+                process::exit(1);
+            }
+        }
+    }
+
+    fn symlink_node_modules(repo_dir: PathBuf) {
+        let current_dir = match current_dir() {
+            Ok(dir) => dir,
+            Err(err) => {
+                eprintln!("Error getting current_dir: {}", err);
+                process::exit(1)
+            }
+        };
+
+        _ = symlink(
+            format!("{}/{NODE_MODULES}", repo_dir.display()),
+            format!("{}/{NODE_MODULES}", current_dir.display()),
+        )
+    }
+}

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -1,17 +1,32 @@
 pub mod ruby {
     const BUNDLE: &str = "bundle";
+    const EXEC: &str = "exec";
 
     pub mod tests {
         pub mod rspec {
             use std::io::{self, Write};
+            use std::path::PathBuf;
             use std::process;
             use std::process::Command;
 
-            use crate::runners::ruby::BUNDLE;
+            use crate::runners::node::{self, PACKAGE_JSON};
+            use crate::runners::ruby::{BUNDLE, EXEC};
+
+            const RSPEC: &str = "rspec";
+
+            // Not every rails app will need this, but if sprockets attempts
+            // to load JS assets in a test it will fail
+            pub fn setup_environment(repo_dir: PathBuf) {
+                if !repo_dir.join(PACKAGE_JSON).exists() {
+                    return;
+                }
+
+                node::setup_environment(repo_dir);
+            }
 
             pub fn run(cached_files: &Vec<String>) {
                 let child = match Command::new(BUNDLE)
-                    .args(["exec", "rspec"])
+                    .args([EXEC, RSPEC])
                     .args(cached_files)
                     .output()
                 {


### PR DESCRIPTION
There are times where `gitavs` is run in a rails project, which may
optionally have a dependency on `node_modules`. These are almost always
being excluded from source control (rightly so). This means that when
`gitavs` creates a worktree, `node_modules` are missing. There isn't a
good way of knowing whether or not the project has a dependency on
sprockets (and by proxy `node_modules`), so this makes it so the `rspec`
runner will attempt to symlink `node_modules` and run `npm install` if
`package.json` is present in the repo directory.
