### PR TITLE
␡ only add changed files that exist

### DIFF
--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -59,14 +59,14 @@ pub fn do_work(from_sha: String) {
             "\x1b[94m[GITAVS]\x1b[0m \x1b[33m{}\x1b[0m {}",
             &commit_pair[1].sha, &commit_pair[1].message
         );
-        print!(" ({i} of {})\n", commits.windows(2).len());
+        print!(" ({i} of {})", commits.windows(2).len());
 
         io::stdout().flush().expect("Failed to flush stdout");
 
         let changed_files = get_changed_files(&commit_pair[0].sha, &commit_pair[1].sha);
 
         if changed_files.is_empty() {
-            println!("\x1b[94m[GITAVS]\x1b[0m No test files");
+            print!(" \x1b[2mNo test files\x1b[0m\n");
 
             i += 1;
 
@@ -82,7 +82,7 @@ pub fn do_work(from_sha: String) {
         checkout(&commit_pair[1].sha);
 
         println!(
-            "\x1b[94m[GITAVS]\x1b[0m Changed files: {}",
+            "\n\x1b[94m[GITAVS]\x1b[0m Changed files: {}",
             changed_files.join(" ")
         );
         println!("\x1b[94m[GITAVS]\x1b[0m Running tests...");

--- a/src/git_client.rs
+++ b/src/git_client.rs
@@ -1,5 +1,6 @@
 use std::env::{current_dir, set_current_dir};
 use std::io::{self, BufRead, BufReader, Write};
+use std::path::Path;
 use std::process::{self, Command, Stdio};
 
 use crate::runners;
@@ -66,6 +67,9 @@ pub fn do_work(from_sha: String) {
 
         if changed_files.is_empty() {
             println!("\x1b[94m[GITAVS]\x1b[0m No test files");
+
+            i += 1;
+
             continue;
         }
 
@@ -144,7 +148,10 @@ fn get_changed_files(sha_1: &String, sha_2: &String) -> Vec<String> {
             BufReader::new(stdout)
                 .lines()
                 .map(|line| line.expect("error"))
-                .filter(|line| line.ends_with("_spec.rb") || line.ends_with("_test.rb"))
+                .filter(|line| {
+                    Path::new(line).exists()
+                        && (line.ends_with("_spec.rb") || line.ends_with("_test.rb"))
+                })
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
Previously, `changed_files` could include deleted files. This caused the test runner to fail because it can't run a test for a file that doesn't exist.

This adds a check using `Path::new(...).exists()` before adding a file to files that will be tested.