### PR TITLE
Rename `from_sha` to `sha`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
 
     while !term.load(Ordering::SeqCst) {
         core::do_work(
-            String::from(cli.from_sha.as_deref().unwrap_or(git::DEFAULT_FROM_SHA)),
+            String::from(cli.sha.as_deref().unwrap_or(git::DEFAULT_FROM_SHA)),
             term,
         );
 
@@ -39,5 +39,5 @@ fn main() -> Result<(), Error> {
 #[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short, long)]
-    from_sha: Option<String>,
+    sha: Option<String>,
 }


### PR DESCRIPTION
I found the usage of this flag odd, especially considering `-f` could be better used as a flag for `file` for configuration files.