### PR TITLE
:toolbox:  Simplify and bubble up global error handling

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Error};
 use std::process::{Command, Stdio};
 
 pub const GIT: &str = "git";
@@ -29,8 +29,8 @@ impl Subcommand {
     }
 }
 
-pub fn get_commits(from_sha: String) -> Vec<Commit> {
-    let child = match Command::new(GIT)
+pub fn get_commits(from_sha: String) -> Result<Vec<Commit>, Error> {
+    let child = Command::new(GIT)
         .args([
             Subcommand::Log.to_string(),
             &format!("{from_sha}^.."),
@@ -38,14 +38,7 @@ pub fn get_commits(from_sha: String) -> Vec<Commit> {
             "--format=%h %s",
         ])
         .stdout(Stdio::piped())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(err) => {
-            eprintln!("Error spawning process: {}", err);
-            std::process::exit(1);
-        }
-    };
+        .spawn()?;
 
     match child.stdout.map(|stdout| {
         BufReader::new(stdout)
@@ -53,26 +46,19 @@ pub fn get_commits(from_sha: String) -> Vec<Commit> {
             .map(|line| build_commit(line))
             .collect::<Vec<Commit>>()
     }) {
-        Some(val) => val,
+        Some(val) => Ok(val),
         None => {
             eprintln!("No commit returned?");
-            Vec::new()
+            Ok(Vec::new())
         }
     }
 }
 
-pub fn get_changed_files(sha_1: &String, sha_2: &String) -> Vec<String> {
-    let child = match Command::new(GIT)
+pub fn get_changed_files(sha_1: &String, sha_2: &String) -> Result<Vec<String>, Error> {
+    let child = Command::new(GIT)
         .args([Subcommand::Diff.to_string(), "--name-only", &sha_1, &sha_2])
         .stdout(Stdio::piped())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(err) => {
-            eprintln!("Error spawning process: {}", err);
-            std::process::exit(1);
-        }
-    };
+        .spawn()?;
 
     let changed_files: Vec<String> = child
         .stdout
@@ -84,55 +70,40 @@ pub fn get_changed_files(sha_1: &String, sha_2: &String) -> Vec<String> {
         })
         .unwrap_or_default();
 
-    changed_files
+    Ok(changed_files)
 }
 
-pub fn checkout(value: &String) {
-    match Command::new(GIT)
+pub fn checkout(value: &String) -> Result<(), Error> {
+    Command::new(GIT)
         .args([Subcommand::Checkout.to_string(), &format!("{}", value)])
-        .output()
-    {
-        Ok(_) => (),
-        Err(err) => {
-            eprintln!("Failed to switch: {}", err);
-            std::process::exit(1);
-        }
-    }
+        .output()?;
+
+    Ok(())
 }
 
-pub fn create_worktree() {
-    match Command::new(GIT)
+pub fn create_worktree() -> Result<(), Error> {
+    Command::new(GIT)
         .args([
             Subcommand::Worktree.to_string(),
             "add",
             "-d",
             &format!("../{WORKTREE_DIR}"),
         ])
-        .output()
-    {
-        Ok(_) => (),
-        Err(err) => {
-            eprintln!("Failed to add worktree: {}", err);
-            std::process::exit(1);
-        }
-    }
+        .output()?;
+
+    Ok(())
 }
 
-pub fn delete_worktree() {
-    match Command::new(GIT)
+pub fn delete_worktree() -> Result<(), Error> {
+    Command::new(GIT)
         .args([
             Subcommand::Worktree.to_string(),
             "remove",
             &format!("../{WORKTREE_DIR}"),
         ])
-        .output()
-    {
-        Ok(_) => (),
-        Err(err) => {
-            eprintln!("Failed to remove worktree: {}", err);
-            std::process::exit(1);
-        }
-    }
+        .output()?;
+
+    Ok(())
 }
 
 fn build_commit<E>(line: Result<String, E>) -> Commit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,16 +21,22 @@ fn main() -> Result<(), Error> {
     signal_hook::flag::register(signal_hook::consts::SIGINT, term.clone())?;
 
     while !term.load(Ordering::SeqCst) {
-        core::do_work(
+        match core::do_work(
             String::from(cli.sha.as_deref().unwrap_or(git::DEFAULT_FROM_SHA)),
             term,
-        );
+        ) {
+            Err(err) => {
+                println!("[TEVA] Failed with error: {err}");
+                println!("[TEVA] Exiting...");
+            },
+            _ => {}
+        }
 
         // break after first iteration because work is not performed in a continuous loop
         break;
     }
 
-    core::cleanup();
+    core::cleanup()?;
 
     Ok(())
 }


### PR DESCRIPTION
There are a lot of `match` expressions in this code base. Specifically around process spawning and interacting with `git`. There isn't yet a clear "escape hatch" to continue using the program when one of these sub processes fail. The previous approach for error handling simply logged a message and exited the process with 1 in each call site. Instead, use `?` and `Result` more to simplify syntax and bubble up errors to the `main` function.