### PR TITLE
:sloth:  Exit when not enough commits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ fn main() -> Result<(), Error> {
     let term = Arc::new(AtomicBool::new(false));
     let cli = Cli::parse();
 
-    display::print_logo();
-
     signal_hook::flag::register(signal_hook::consts::SIGINT, term.clone())?;
 
     while !term.load(Ordering::SeqCst) {
@@ -28,7 +26,7 @@ fn main() -> Result<(), Error> {
             Err(err) => {
                 println!("\x1b[94m[TEVA]\x1b[0m Failed with error: {err}");
                 println!("\x1b[94m[TEVA]\x1b[0m Exiting...");
-            },
+            }
             _ => {}
         }
 


### PR DESCRIPTION
If the number of commits on the current branch from `main` to `HEAD` is <= 1, `teva` isn't going to do anything. This can be confusing and should be handled differently.

Instead of quietly proceeding, this prints a message and exits the process.