### PR TITLE
:wrench: Pass files to runners as string vector

### DIFF
--- a/src/runners.rs
+++ b/src/runners.rs
@@ -32,6 +32,9 @@ pub mod ruby {
                     .filter(|file| Path::new(file).exists() && file.ends_with("_spec.rb"))
                     .collect::<Vec<String>>();
 
+                if runnable_files.is_empty() {
+                    return Ok(());
+                }
 
                 Command::new(BUNDLE)
                     .args([EXEC, RSPEC])

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -28,12 +28,14 @@ pub mod ruby {
             pub fn run(cached_files: &Vec<String>) -> Result<(), Error> {
                 let runnable_files = cached_files
                     .iter()
-                    .filter(|file| Path::new(file).exists())
-                    .filter(|file| file.ends_with("_spec.rb"));
+                    .map(|file| file.clone())
+                    .filter(|file| Path::new(file).exists() && file.ends_with("_spec.rb"))
+                    .collect::<Vec<String>>();
+
 
                 Command::new(BUNDLE)
                     .args([EXEC, RSPEC])
-                    .args(runnable_files)
+                    .args(&runnable_files)
                     .stderr(Stdio::null())
                     .spawn()
                     .unwrap()


### PR DESCRIPTION
There was a regression where the files arg passed to the rspec runner
were not a vector of file strings. Regardless of how this was treated by
the command builder, it resulted in `bundle exec rspec` which attempted
to run the whole test suite every time.

This joins vector into a vector of strings and passes it to the runnner
command.