### PR TITLE
:file_folder: Use `/tmp` instead of parent dir for worktree

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -26,7 +26,7 @@ fn setup_environment(repo_dir: std::path::PathBuf) -> Result<(), Error> {
 
     git::create_worktree()?;
 
-    if std::env::set_current_dir(&format!("../{}", git::WORKTREE_DIR).to_string()).is_err() {
+    if std::env::set_current_dir(&format!("/tmp/{}", git::WORKTREE_DIR).to_string()).is_err() {
         eprintln!("Error, couldn't change to worktree directory");
         git::delete_worktree()?;
         std::process::exit(1);

--- a/src/git.rs
+++ b/src/git.rs
@@ -87,7 +87,7 @@ pub fn create_worktree() -> Result<(), Error> {
             Subcommand::Worktree.to_string(),
             "add",
             "-d",
-            &format!("../{WORKTREE_DIR}"),
+            &format!("/tmp/{WORKTREE_DIR}"),
         ])
         .output()?;
 
@@ -99,7 +99,7 @@ pub fn delete_worktree() -> Result<(), Error> {
         .args([
             Subcommand::Worktree.to_string(),
             "remove",
-            &format!("../{WORKTREE_DIR}"),
+            &format!("/tmp/{WORKTREE_DIR}"),
         ])
         .output()?;
 


### PR DESCRIPTION
Instead of using a parent directory for creating the git worktree, instead use `/tmp` which is a directory for temporary file storage.

It still requires cleaning up the directory if the process is terminated with SIGINT.