### PR TITLE
Only set git config values in CI

### DIFF
--- a/tests/fixtures/sanity_check_with_rspec/setup.sh
+++ b/tests/fixtures/sanity_check_with_rspec/setup.sh
@@ -8,9 +8,14 @@ echo "Done"
 echo "Installing dependencies..."
 bundle install --gemfile=$1/Gemfile
 echo "Initializing git repository..."
-git config --global user.name 'Your name'
-git config --global user.email 'you@example.com'
-git config --global init.defaultBranch main
+
+if ! test -f ~/.gitconfig; then
+  touch ~/.gitconfig
+  git config --global user.name 'Your name'
+  git config --global user.email 'you@example.com'
+  git config --global init.defaultBranch main
+fi
+
 git init $1
 echo "Committing files..."
 git -C $1 add init.rb spec/init_spec.rb Gemfile Gemfile.lock


### PR DESCRIPTION
There were some leaky config values in the test setup script that unset
local dev git config files. Obviously, this shouldn't happen.