### PR TITLE
add `rust-fmt-check` GitHub action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,3 +21,12 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+  rustfmt_check: 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - uses: clechasseur/rs-fmt-check@v2

--- a/src/git.rs
+++ b/src/git.rs
@@ -35,21 +35,13 @@ impl Client {
     }
 
     pub fn get_changed_files(&self, sha_1: &String, sha_2: &String) -> Vec<String> {
-        let output = self.execute_command(vec![
-            "diff",
-            "--name-only",
-            &sha_1,
-            &sha_2,
-        ]);
+        let output = self.execute_command(vec!["diff", "--name-only", &sha_1, &sha_2]);
 
         self.transform_stream(output.stdout)
     }
 
     pub fn checkout(&self, value: &String) -> Result<(), Error> {
-        self.execute_command(vec![
-            "checkout",
-            &format!("{}", value),
-        ]);
+        self.execute_command(vec!["checkout", &format!("{}", value)]);
 
         Ok(())
     }
@@ -66,11 +58,7 @@ impl Client {
     }
 
     pub fn delete_worktree(&self) -> Result<(), Error> {
-        self.execute_command(vec![
-            "worktree",
-            "remove",
-            &format!("/tmp/{WORKTREE_DIR}"),
-        ]);
+        self.execute_command(vec!["worktree", "remove", &format!("/tmp/{WORKTREE_DIR}")]);
 
         Ok(())
     }


### PR DESCRIPTION
There have been a few times that commits have not been formatted
correctly with `rustfmt`. This adds a GitHub action to check for that
and provide annotations.