### PR TITLE
:evergreen_tree: Always prune teva worktree, change `.teva.toml` requirements

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -43,7 +43,7 @@ fn setup_environment(client: &Client, config: &Config) -> Result<(), Box<dyn Err
 
     runners::setup(config)?;
 
-    print!("{} Done ✔️\n", "[teva]".blue());
+    print!(" Done ✔️\n");
 
     Ok(())
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -32,6 +32,7 @@ pub fn do_work(
 fn setup_environment(client: &Client, config: &Config) -> Result<(), Box<dyn Error>> {
     print!("{} ⚙️ Setting up environment...", "[teva]".blue());
 
+    client.delete_worktree()?;
     client.create_worktree()?;
 
     if std::env::set_current_dir(&format!("/tmp/{}", git::WORKTREE_DIR).to_string()).is_err() {
@@ -100,10 +101,6 @@ where
 
 pub fn cleanup(client: &Client) -> Result<(), Box<dyn Error>> {
     client.delete_worktree()?;
-
-    Command::new("rm")
-        .args(["-rf", "/tmp/teva-worktree"])
-        .output()?;
 
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,7 +21,8 @@ pub struct Setup {
 
 #[derive(Debug, Deserialize)]
 pub struct Run {
-    pub steps: Vec<Step>,
+    pub command: String,
+    pub args: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -63,9 +64,9 @@ mod tests {
                 ]
 
                 [test.run]
-                steps = [
-                    { name = "rspec", command = "bundle", args = ["exec", "rspec" ] },
-                ]
+                name = "rspec"
+                command = "bundle"
+                args = ["exec", "rspec"]
                 "#;
             writeln!(tmp_file, "{}", toml)?;
 
@@ -75,7 +76,7 @@ mod tests {
 
             let result = config?;
             let test = result.test.setup.unwrap().steps;
-            let run = result.test.run.unwrap().steps;
+            let run = result.test.run.unwrap();
 
             assert_eq!("_spec.rb", result.test.pattern);
             assert_eq!(2, test.len());
@@ -87,11 +88,10 @@ mod tests {
                 test.get(1).unwrap().args.clone().unwrap()
             );
 
-            assert_eq!(1, run.len());
-            assert_eq!("bundle", run.first().unwrap().command);
+            assert_eq!("bundle", run.command);
             assert_eq!(
                 ["exec".to_string(), "rspec".to_string()].to_vec(),
-                run.first().unwrap().args.clone().unwrap()
+                run.args.clone().unwrap()
             );
 
             Ok(())

--- a/src/runners.rs
+++ b/src/runners.rs
@@ -47,14 +47,12 @@ pub fn run(config: &Config, cached_files: &Vec<String>) -> Result<(), Box<dyn Er
     }
 
     if let Some(run) = &config.test.run {
-        for step in &run.steps {
-            Command::new(&step.command)
-                .args(step.args.as_deref().unwrap_or_default())
-                .args(&runnable_files)
-                .stderr(Stdio::null())
-                .spawn()?
-                .wait_with_output()?;
-        }
+        Command::new(&run.command)
+            .args(run.args.as_deref().unwrap_or_default())
+            .args(&runnable_files)
+            .stderr(Stdio::null())
+            .spawn()?
+            .wait_with_output()?;
     }
 
     Ok(())

--- a/tests/fixtures/sanity_check_with_rspec/.teva.toml
+++ b/tests/fixtures/sanity_check_with_rspec/.teva.toml
@@ -3,4 +3,5 @@ pattern = "_spec.rb"
 [test.setup]
 steps = [ { name = "hello", command = "echo", args = ["foo"] } ]
 [test.run]
-steps = [ { name = "rspec", command = "bundle", args = ["exec", "rspec"] } ]
+command = "bundle"
+args = ["exec", "rspec"]

--- a/tests/snapshots/cli__sanity_check_with_rspec.snap
+++ b/tests/snapshots/cli__sanity_check_with_rspec.snap
@@ -5,7 +5,7 @@ expression: result
 [teva] ⚙️ Setting up environment...
 [teva] Step (1 of 1) `hello`
 foo
-[teva] Done ✔️
+ Done ✔️
 [teva] [SHA] add bar (1 of 3)
 [teva] Changed files: bar.rb spec/bar_spec.rb
 [teva] Running tests...


### PR DESCRIPTION
Sometimes if `teva` was interrupted with SIGINT when it was still
running the `teva-worktree` will still be around in a detached head
state. This causes the executable to fail with subsequent runs.

This makes it so `teva` always removes any existing worktrees and runs
`git worktree prune` before before running to ensure it always starts
with a fresh slate.

Previously, the `.teva.toml` file expected the `test.run` to contain a
single array of inline tables. It implied that there could be multiple
commands within the `test.run` step. In reality, there should really
only be one.

This converts the array of inline tables into a set of key value pairs
with `command` and `args`. This is more clear.